### PR TITLE
Mark all classes as available iOS10+

### DIFF
--- a/InstantSearchVoiceOverlay.podspec
+++ b/InstantSearchVoiceOverlay.podspec
@@ -8,14 +8,14 @@ Pod::Spec.new do |s|
     s.author           = { "Algolia" => "contact@algolia.com" }
     s.source           = { git: "https://github.com/algolia/voice-overlay-ios.git", tag: s.version.to_s }
     s.social_media_url = 'https://twitter.com/algolia'
-    s.ios.deployment_target = '10.0'
+    s.ios.deployment_target = '9.0'
     s.requires_arc = true
     s.swift_version = '4.2'
 
         # Build settings
     # --------------
     # NOTE: Deployment targets should be kept in line with the API Client.
-    s.ios.deployment_target = '10.0'
+    s.ios.deployment_target = '9.0'
 
     s.source_files = [
         'VoiceOverlay/**/*.{swift}'

--- a/VoiceOverlay.xcodeproj/project.pbxproj
+++ b/VoiceOverlay.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = VoiceOverlay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -393,6 +394,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = VoiceOverlay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/VoiceOverlay/Controllers/NoPermissionViewController.swift
+++ b/VoiceOverlay/Controllers/NoPermissionViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 10.0, *)
 public class NoPermissionViewController: UIViewController {
     
     var dismissHandler: (() -> ())? = nil

--- a/VoiceOverlay/Controllers/PermissionViewController.swift
+++ b/VoiceOverlay/Controllers/PermissionViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import AVFoundation
 
+@available(iOS 10.0, *)
 class PermissionViewController: UIViewController {
     
     var dismissHandler: (() -> ())? = nil

--- a/VoiceOverlay/Controllers/RecordingViewController.swift
+++ b/VoiceOverlay/Controllers/RecordingViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 10.0, *)
 class InputViewController: UIViewController {
   
   var speechController: SpeechController?

--- a/VoiceOverlay/Controllers/ResultViewController.swift
+++ b/VoiceOverlay/Controllers/ResultViewController.swift
@@ -8,8 +8,7 @@
 
 import UIKit
 
-import UIKit
-
+@available(iOS 10.0, *)
 public class ResultViewController: UIViewController {
   
   public var constants: ResultScreenConstants!

--- a/VoiceOverlay/Controllers/VoiceOverlayController.swift
+++ b/VoiceOverlay/Controllers/VoiceOverlayController.swift
@@ -11,6 +11,7 @@ import UIKit
 import Speech
 
 /// Controller that takes care of launching a voice overlay and providing handlers to listen to text and error events.
+@available(iOS 10.0, *)
 @objc public class VoiceOverlayController: NSObject {
     
     let permissionViewController = PermissionViewController()

--- a/VoiceOverlay/Helpers/AutoLayoutHelpers.swift
+++ b/VoiceOverlay/Helpers/AutoLayoutHelpers.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 
+@available(iOS 10.0, *)
 class ViewHelpers {
     static func setConstraintsForTitleLabel(_ titleLabel: UILabel, _ margins: UILayoutGuide, _ text: String, _ textColor: UIColor) {
         setDefaultSideConstraints(to: titleLabel, in: margins)

--- a/VoiceOverlay/Views/AllowPermissionButton.swift
+++ b/VoiceOverlay/Views/AllowPermissionButton.swift
@@ -11,6 +11,7 @@ import CoreGraphics
 import UIKit
 
 // we have to have this class or else when using autolayout, the gradient won't redraw itself.
+@available(iOS 10.0, *)
 public class FirstPermissionButton: UIButton {
     
     var startColor: UIColor = .white

--- a/VoiceOverlay/Views/CloseView.swift
+++ b/VoiceOverlay/Views/CloseView.swift
@@ -9,6 +9,7 @@
 import Foundation
 import UIKit
 
+@available(iOS 10.0, *)
 public class CloseView: UIView
 {
     override public func draw(_ rect: CGRect)

--- a/VoiceOverlay/Views/RecordingButton.swift
+++ b/VoiceOverlay/Views/RecordingButton.swift
@@ -9,6 +9,7 @@
 import UIKit
 import AVFoundation
 
+@available(iOS 10.0, *)
 @IBDesignable
 public class RecordingButton: UIButton {
   
@@ -101,6 +102,7 @@ enum RecordingStatus {
     case startRecording, endRecording, error
 }
 
+@available(iOS 10.0, *)
 extension RecordingButton {
     func setimage(_ isRecording: Bool) {
         let imageName = isRecording ? "mic-lg-active" : "mic-lg-inactive"


### PR DESCRIPTION
This is so that people can still use the library through CocoaPods when using iOS 9+

Solves #3 