### PR TITLE
feat: Make the speech to text controller abstract. Add custom data to the handler

### DIFF
--- a/VoiceOverlay.xcodeproj/project.pbxproj
+++ b/VoiceOverlay.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1DD20F5A21773D5E008DC1D7 /* Recordable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD20F5921773D5E008DC1D7 /* Recordable.swift */; };
 		E236003520F4EA4300F42359 /* ResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E236003420F4EA4300F42359 /* ResultViewController.swift */; };
 		E264699F20E512C600ABD287 /* NoPermissionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E264699E20E512C600ABD287 /* NoPermissionViewController.swift */; };
 		E27D294B20E0F0C900B83D4C /* VoiceOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = E27D294920E0F0C900B83D4C /* VoiceOverlay.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -27,6 +28,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1DD20F5921773D5E008DC1D7 /* Recordable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recordable.swift; sourceTree = "<group>"; };
 		E236003420F4EA4300F42359 /* ResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewController.swift; sourceTree = "<group>"; };
 		E264699E20E512C600ABD287 /* NoPermissionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoPermissionViewController.swift; sourceTree = "<group>"; };
 		E27D294620E0F0C900B83D4C /* InstantSearchVoiceOverlay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = InstantSearchVoiceOverlay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -59,6 +61,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1DD20F5821773D5E008DC1D7 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				1DD20F5921773D5E008DC1D7 /* Recordable.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
 		E27D293C20E0F0C900B83D4C = {
 			isa = PBXGroup;
 			children = (
@@ -78,6 +88,7 @@
 		E27D294820E0F0C900B83D4C /* VoiceOverlay */ = {
 			isa = PBXGroup;
 			children = (
+				1DD20F5821773D5E008DC1D7 /* Protocols */,
 				E29EEC8820E3B1AB00415FCF /* Sound */,
 				E29EEC5C20E11AE900415FCF /* Controllers */,
 				E29EEC5B20E11AE400415FCF /* Views */,
@@ -224,6 +235,7 @@
 				E27D295A20E0F20D00B83D4C /* PermissionViewController.swift in Sources */,
 				E27D295820E0F20D00B83D4C /* CloseView.swift in Sources */,
 				E27D295920E0F20D00B83D4C /* AllowPermissionButton.swift in Sources */,
+				1DD20F5A21773D5E008DC1D7 /* Recordable.swift in Sources */,
 				E264699F20E512C600ABD287 /* NoPermissionViewController.swift in Sources */,
 				E29EEC6220E143AE00415FCF /* SpeechController.swift in Sources */,
 				E236003520F4EA4300F42359 /* ResultViewController.swift in Sources */,

--- a/VoiceOverlay.xcodeproj/xcshareddata/xcschemes/VoiceOverlay.xcscheme
+++ b/VoiceOverlay.xcodeproj/xcshareddata/xcschemes/VoiceOverlay.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E27D294520E0F0C900B83D4C"
-               BuildableName = "VoiceOverlay.framework"
+               BuildableName = "InstantSearchVoiceOverlay.framework"
                BlueprintName = "VoiceOverlay"
                ReferencedContainer = "container:VoiceOverlay.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E27D294520E0F0C900B83D4C"
-            BuildableName = "VoiceOverlay.framework"
+            BuildableName = "InstantSearchVoiceOverlay.framework"
             BlueprintName = "VoiceOverlay"
             ReferencedContainer = "container:VoiceOverlay.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E27D294520E0F0C900B83D4C"
-            BuildableName = "VoiceOverlay.framework"
+            BuildableName = "InstantSearchVoiceOverlay.framework"
             BlueprintName = "VoiceOverlay"
             ReferencedContainer = "container:VoiceOverlay.xcodeproj">
          </BuildableReference>

--- a/VoiceOverlay/Controllers/PermissionViewController.swift
+++ b/VoiceOverlay/Controllers/PermissionViewController.swift
@@ -12,7 +12,7 @@ import AVFoundation
 class PermissionViewController: UIViewController {
     
     var dismissHandler: (() -> ())? = nil
-    var speechController: SpeechController!
+    var speechController: Recordable!
   
     var constants: PermissionScreenConstants!
     let titleLabel = UILabel()

--- a/VoiceOverlay/Controllers/RecordingViewController.swift
+++ b/VoiceOverlay/Controllers/RecordingViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class InputViewController: UIViewController {
   
-  var speechController: SpeechController?
+  var speechController: Recordable?
   
   var speechTextHandler: SpeechTextHandler?
   var speechErrorHandler: SpeechErrorHandler?
@@ -28,6 +28,7 @@ class InputViewController: UIViewController {
   var autoStopTimer: Timer = Timer()
   
   var speechText: String?
+  var customData: Any?
   var speechError: Error?
   
   var constants: InputScreenConstants!
@@ -127,7 +128,7 @@ class InputViewController: UIViewController {
       self.delegate?.recording(text: self.speechText, final: true, error: self.speechError)
       
       if let speechText = self.speechText {
-        self.speechTextHandler?(speechText, true)
+        self.speechTextHandler?(speechText, true, self.customData)
       } else {
         self.speechErrorHandler?(self.speechError)
       }
@@ -148,10 +149,11 @@ class InputViewController: UIViewController {
     // TODO: Playing sound is crashing. probably because we re not stopping play, or interfering with speech controller, or setActive true/false in playSound
     //recordingButton.playSound(with: isRecording ? .startRecording : .endRecording)
     
-    speechController?.startRecording(textHandler: {[weak self] (text, final) in
+    speechController?.startRecording(textHandler: {[weak self] (text, final, customData) in
       guard let strongSelf = self else { return }
       
       strongSelf.speechText = text
+      strongSelf.customData = customData
       strongSelf.speechError = nil
       strongSelf.subtitleLabel.text = text
       strongSelf.subtitleBulletLabel.text = ""
@@ -164,7 +166,7 @@ class InputViewController: UIViewController {
       } else {
         if strongSelf.isRecording {
           strongSelf.delegate?.recording(text: text, final: final, error: nil)
-          strongSelf.speechTextHandler?(text, final)
+          strongSelf.speechTextHandler?(text, final, customData)
         }
       }
 
@@ -179,6 +181,7 @@ class InputViewController: UIViewController {
         guard let strongSelf = self else { return }
         
         strongSelf.speechText = nil
+        strongSelf.customData = nil
         strongSelf.speechError = error
         strongSelf.delegate?.recording(text: nil, final: nil, error: error)
         strongSelf.speechErrorHandler?(error)

--- a/VoiceOverlay/Controllers/SpeechController.swift
+++ b/VoiceOverlay/Controllers/SpeechController.swift
@@ -9,7 +9,7 @@ import UIKit
 import Speech
 import AVFoundation
 
-public typealias SpeechTextHandler = (String, Bool) -> Void
+public typealias SpeechTextHandler = (String, Bool, Any?) -> Void
 public typealias SpeechResultScreenHandler = (String) -> Void
 public typealias SpeechErrorHandler = (Error?) -> Void
 
@@ -20,7 +20,7 @@ public typealias SpeechErrorHandler = (Error?) -> Void
 /// let speechController = SpeechController(locale: Locale(identifier: "fr_FR"))
 /// Do not forget to add `NSSpeechRecognitionUsageDescription` and `NSMicrophoneUsageDescription` to your Info.plist
 @available(iOS 10.0, *)
-@objc public class SpeechController: NSObject, SFSpeechRecognizerDelegate {
+@objc public class SpeechController: NSObject, SFSpeechRecognizerDelegate, Recordable {
   private static let AUDIO_BUFFER_SIZE: UInt32 = 1024
   private let speechRecognizer: SFSpeechRecognizer
   private var speechRequest: SFSpeechAudioBufferRecognitionRequest?
@@ -119,7 +119,7 @@ public typealias SpeechErrorHandler = (Error?) -> Void
       if let r = result {
         let transcription = r.bestTranscription
         let isFinal = r.isFinal
-        textHandler(transcription.formattedString, isFinal)
+        textHandler(transcription.formattedString, isFinal, nil)
       } else {
         errorHandler(error)
       }

--- a/VoiceOverlay/Controllers/VoiceOverlayController.swift
+++ b/VoiceOverlay/Controllers/VoiceOverlayController.swift
@@ -10,12 +10,14 @@ import Foundation
 import UIKit
 import Speech
 
+public typealias RecordableHandler = () -> Recordable
+
 /// Controller that takes care of launching a voice overlay and providing handlers to listen to text and error events.
 @objc public class VoiceOverlayController: NSObject {
     
     let permissionViewController = PermissionViewController()
     let noPermissionViewController = NoPermissionViewController()
-    let speechController = SpeechController()
+    let recordableHandler: RecordableHandler
     public weak var delegate: VoiceOverlayDelegate?
     var speechTextHandler: SpeechTextHandler?
     var speechErrorHandler: SpeechErrorHandler?
@@ -27,7 +29,15 @@ import Speech
     public var datasource: Any? = nil
   
     public override init() {
-        super.init()
+      self.recordableHandler = {
+        return SpeechController()
+      }
+      super.init()
+    }
+  
+    public init(speechControllerHandler: @escaping RecordableHandler) {
+      self.recordableHandler = speechControllerHandler
+      super.init()
     }
     
     @objc public func start(on view: UIViewController, textHandler: @escaping SpeechTextHandler, errorHandler: @escaping SpeechErrorHandler, resultScreenHandler: SpeechResultScreenHandler? = nil) {
@@ -76,7 +86,7 @@ import Speech
     }
     
     fileprivate func showPermissionScreen(_ view: UIViewController) {
-        permissionViewController.speechController = speechController
+        permissionViewController.speechController = recordableHandler()
         permissionViewController.constants = settings.layout.permissionScreen
         view.present(permissionViewController, animated: true)
     }
@@ -93,7 +103,7 @@ import Speech
         inputViewController.speechTextHandler = speechTextHandler
         inputViewController.speechErrorHandler = speechErrorHandler
         inputViewController.speechResultScreenHandler = speechResultScreenHandler
-        inputViewController.speechController = SpeechController()
+        inputViewController.speechController = recordableHandler()
         inputViewController.constants = settings.layout.inputScreen
         inputViewController.settings = settings
     

--- a/VoiceOverlay/Protocols/Recordable.swift
+++ b/VoiceOverlay/Protocols/Recordable.swift
@@ -1,0 +1,20 @@
+//
+//  Recordable.swift
+//  InstantSearchVoiceOverlay
+//
+//  Created by Robert Mogos on 17/10/2018.
+//
+
+import Foundation
+
+public protocol Recordable {
+  func startRecording(textHandler: @escaping SpeechTextHandler, errorHandler: @escaping SpeechErrorHandler)
+  
+  func stopRecording()
+  
+  func isRecording() -> Bool
+  
+  func requestAuthorization(_ statusHandler: @escaping (Bool) -> Void)
+}
+
+

--- a/VoiceOverlay/Protocols/Recordable.swift
+++ b/VoiceOverlay/Protocols/Recordable.swift
@@ -7,13 +7,19 @@
 
 import Foundation
 
+/// Protocol that allows to inject any STT into the voice overlay
 public protocol Recordable {
+  
+  // Starting the recording and processing the STT
   func startRecording(textHandler: @escaping SpeechTextHandler, errorHandler: @escaping SpeechErrorHandler)
   
+  // Stop the recording
   func stopRecording()
   
+  // Get the state of the recording
   func isRecording() -> Bool
   
+  // Request system authorisation for STT and Voice capabilies
   func requestAuthorization(_ statusHandler: @escaping (Bool) -> Void)
 }
 


### PR DESCRIPTION
* Make the `InputViewController` and `PermissionViewController` use a `Recordable` instead of a `SpeechController`. This will allow us to inject any STT and not limit us to the default one
* Add `customData` to the speech handler since the STT might return some custom data like the intent or any additional processing done on the speech